### PR TITLE
Refactor story scenes into modular components

### DIFF
--- a/src/components/StoryScene.vue
+++ b/src/components/StoryScene.vue
@@ -1,684 +1,125 @@
 <template>
   <div class="story-container">
-    <!-- Progress indicator -->
-    <div class="progress-bar">
-      <div class="progress-fill" :style="{ width: `${progressPercentage}%` }"></div>
-      <div class="progress-dots">
-        <button
-          v-for="(scene, index) in scenes"
-          :key="index"
-          @click="currentSceneIndex = index"
-          class="progress-dot"
-          :class="{
-            active: index === currentSceneIndex,
-            visited: index < currentSceneIndex
-          }"
-          :title="scene.title"
-        ></button>
-      </div>
-    </div>
+    <StoryProgress
+      :scenes="scenes"
+      :current-scene-index="currentSceneIndex"
+      @change="goToScene"
+    />
 
-    <!-- Scene content -->
     <transition name="fade" mode="out-in">
       <div :key="currentSceneIndex" class="scene-wrapper">
-
-        <!-- All scenes now use the same unified container -->
         <div
           class="scene-content-unified"
-          :class="{ 'has-background': currentScene.backgroundImage }"
-          :style="currentScene.backgroundImage ? { '--bg-image': `url(${currentScene.backgroundImage})` } : {}"
+          :class="{ 'has-background': hasBackground }"
+          :style="backgroundStyle"
         >
-
-          <!-- Hero scene -->
-          <div v-if="currentScene.type === 'hero'" class="unified-hero-content">
-            <div class="hero-content">
-              <h1 class="hero-title">{{ currentScene.title }}</h1>
-              <p class="hero-description">
-                <span class="typewriter-text">{{ displayedText }}</span>
-                <span class="cursor" :class="{ 'visible': showCursor }">|</span>
-              </p>
-              <button @click="nextScene" class="hero-cta">
-                {{ currentScene.ctaText || 'Start Journey' }} →
-              </button>
-            </div>
-          </div>
-
-          <!-- Default text scene -->
-          <div v-else-if="!currentScene.type || currentScene.type === 'text'" class="unified-text-content">
-            <div class="scene-text">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-description">{{ currentScene.description }}</p>
-
-              <!-- Compass for future scene -->
-              <div v-if="currentScene.showCompass" class="compass-container">
-                <svg viewBox="0 0 200 200" class="compass-svg">
-                  <defs>
-                    <radialGradient id="outerRing" cx="50%" cy="50%" r="50%">
-                      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.2"/>
-                      <stop offset="70%" style="stop-color:#ffffff;stop-opacity:0.1"/>
-                      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0.3"/>
-                    </radialGradient>
-
-                    <radialGradient id="innerRing" cx="50%" cy="50%" r="50%">
-                      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.3"/>
-                      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0.1"/>
-                    </radialGradient>
-
-                    <linearGradient id="needleNorth" x1="0%" y1="0%" x2="0%" y2="100%">
-                      <stop offset="0%" style="stop-color:#ff6666"/>
-                      <stop offset="100%" style="stop-color:#dd0000"/>
-                    </linearGradient>
-
-                    <linearGradient id="needleSouth" x1="0%" y1="0%" x2="0%" y2="100%">
-                      <stop offset="0%" style="stop-color:#666666"/>
-                      <stop offset="100%" style="stop-color:#333333"/>
-                    </linearGradient>
-
-                    <filter id="glow">
-                      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-                      <feMerge>
-                        <feMergeNode in="coloredBlur"/>
-                        <feMergeNode in="SourceGraphic"/>
-                      </feMerge>
-                    </filter>
-                  </defs>
-
-                  <circle cx="100" cy="100" r="90" fill="none" stroke="url(#outerRing)" stroke-width="3" opacity="0.8"/>
-                  <circle cx="100" cy="100" r="70" fill="none" stroke="url(#innerRing)" stroke-width="2" opacity="0.6"/>
-
-                  <g stroke="rgba(255,255,255,0.7)" stroke-width="2" fill="none">
-                    <line x1="100" y1="20" x2="100" y2="35"/>
-                    <line x1="180" y1="100" x2="165" y2="100"/>
-                    <line x1="100" y1="180" x2="100" y2="165"/>
-                    <line x1="20" y1="100" x2="35" y2="100"/>
-                  </g>
-
-                  <g stroke="rgba(255,255,255,0.5)" stroke-width="1" fill="none">
-                    <line x1="163.6" y1="36.4" x2="156.4" y2="43.6"/>
-                    <line x1="163.6" y1="163.6" x2="156.4" y2="156.4"/>
-                    <line x1="36.4" y1="163.6" x2="43.6" y2="156.4"/>
-                    <line x1="36.4" y1="36.4" x2="43.6" y2="43.6"/>
-                  </g>
-
-                  <g fill="rgba(255,255,255,0.9)" font-family="Arial, sans-serif" font-size="16" font-weight="bold" text-anchor="middle">
-                    <text x="100" y="15" dominant-baseline="middle">N</text>
-                    <text x="190" y="105" dominant-baseline="middle">O</text>
-                    <text x="100" y="195" dominant-baseline="middle">Z</text>
-                    <text x="10" y="105" dominant-baseline="middle">W</text>
-                  </g>
-
-                  <g filter="url(#glow)">
-                    <polygon points="100,100 95,45 100,35 105,45" fill="url(#needleNorth)" stroke="rgba(255,255,255,0.3)" stroke-width="1">
-                      <animateTransform attributeName="transform" attributeType="XML" type="rotate" values="0 100 100;5 100 100;-5 100 100;0 100 100" dur="4s" repeatCount="indefinite"/>
-                    </polygon>
-
-                    <polygon points="100,100 105,155 100,165 95,155" fill="url(#needleSouth)" stroke="rgba(255,255,255,0.2)" stroke-width="1">
-                      <animateTransform attributeName="transform" attributeType="XML" type="rotate" values="0 100 100;5 100 100;-5 100 100;0 100 100" dur="4s" repeatCount="indefinite"/>
-                    </polygon>
-                  </g>
-
-                  <circle cx="100" cy="100" r="6" fill="rgba(255,255,255,0.9)" stroke="rgba(255,102,102,0.8)" stroke-width="2">
-                    <animate attributeName="r" values="6;8;6" dur="2s" repeatCount="indefinite"/>
-                  </circle>
-
-                  <g stroke="rgba(255,255,255,0.3)" stroke-width="1" fill="none">
-                    <path d="M 30 30 L 40 30 M 30 30 L 30 40"/>
-                    <path d="M 170 30 L 160 30 M 170 30 L 170 40"/>
-                    <path d="M 170 170 L 160 170 M 170 170 L 170 160"/>
-                    <path d="M 30 170 L 40 170 M 30 170 L 30 160"/>
-                  </g>
-
-<!--                  <text x="100" y="25" fill="rgba(255,255,255,0.7)" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-style="italic">Eigen Koers</text>-->
-                </svg>
-              </div>
-
-              <ul v-if="currentScene.points" class="scene-points-text">
-                <li v-for="(point, idx) in currentScene.points" :key="idx">
-                  {{ point }}
-                </li>
-              </ul>
-            </div>
-
-            <div class="unified-navigation">
-              <div class="scene-navigation">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <span class="scene-counter">{{ currentSceneIndex + 1 }} / {{ scenes.length }}</span>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Stats showcase scene -->
-          <div v-else-if="currentScene.type === 'stats'" class="unified-stats-content">
-            <h2 class="scene-title">{{ currentScene.title }}</h2>
-            <div class="stats-grid">
-              <div v-for="stat in currentScene.stats" :key="stat.label" class="stat-card">
-                <div class="stat-value">{{ stat.value }}</div>
-                <div class="stat-label">{{ stat.label }}</div>
-                <div v-if="stat.detail" class="stat-detail">{{ stat.detail }}</div>
-              </div>
-            </div>
-            <div class="unified-navigation">
-              <div class="scene-navigation">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Images showcase scene -->
-          <div v-else-if="currentScene.type === 'images'" class="unified-images-content">
-            <h2 class="scene-title">{{ currentScene.title }}</h2>
-            <div class="images-grid">
-              <div v-for="image in currentScene.images" :key="image.alt" class="image-card">
-                <img :src="image.src" :alt="image.alt" class="performance-image" />
-                <div class="image-caption">{{ image.caption }}</div>
-              </div>
-            </div>
-            <div class="unified-navigation">
-              <div class="scene-navigation">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- UTP Connection scene -->
-          <div v-else-if="currentScene.type === 'utp'" class="unified-utp-content">
-            <h2 class="scene-title">{{ currentScene.title }}</h2>
-            <p class="scene-description">{{ currentScene.description }}</p>
-
-            <div class="utp-visualization">
-              <div class="pc-box left-pc">
-                <div class="pc-label">LLM Machine</div>
-                <div class="pc-icon">💻</div>
-              </div>
-
-              <div class="utp-cable">
-                <div class="cable-line"></div>
-                <div class="data-flow"></div>
-                <div class="cable-label">UTP ethernet Kabel</div>
-              </div>
-
-              <div class="pc-box right-pc">
-                <div class="pc-label">Whisper Machine</div>
-                <div class="pc-icon">💻</div>
-              </div>
-            </div>
-
-            <ul v-if="currentScene.points" class="scene-points">
-              <li v-for="(point, idx) in currentScene.points" :key="idx">
-                {{ point }}
-              </li>
-            </ul>
-
-            <div class="unified-navigation">
-              <div class="scene-navigation">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Chat interface scene -->
-          <div v-else-if="currentScene.type === 'chat'" class="unified-chat-content">
-            <div class="scene-header">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-subtitle">{{ currentScene.description }}</p>
-            </div>
-
-            <ChatInterface
-              v-if="currentScene.type === 'chat'"
-              @streaming-change="handleStreamingChange"
-            />
-
-            <div class="unified-navigation-minimal">
-              <div class="scene-navigation-minimal">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Terug
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Doorgaan →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- WhisperLive interface scene -->
-          <div v-else-if="currentScene.type === 'whisper'" class="unified-chat-content">
-            <div class="scene-header">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-subtitle">{{ currentScene.description }}</p>
-            </div>
-
-            <WhisperLiveInterface
-              v-if="currentScene.type === 'whisper'"
-              @streaming-change="handleStreamingChange"
-            />
-
-            <div class="unified-navigation-minimal">
-              <div class="scene-navigation-minimal">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Terug
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Doorgaan →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Conversation interface scene -->
-          <div v-else-if="currentScene.type === 'conversation'" class="unified-chat-content">
-            <div class="scene-header">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-subtitle">{{ currentScene.description }}</p>
-            </div>
-
-            <ConversationInterface
-              v-if="currentScene.type === 'conversation'"
-              @streaming-change="handleStreamingChange"
-              @conversation-state-change="handleConversationStateChange"
-            />
-
-            <div class="unified-navigation-minimal">
-              <div class="scene-navigation-minimal">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Terug
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Doorgaan →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Split view scene -->
-          <div v-else-if="currentScene.type === 'split'" class="unified-split-content">
-            <div class="split-left">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-description">{{ currentScene.description }}</p>
-              <div v-if="currentScene.code" class="code-block">
-                <pre><code>{{ currentScene.code }}</code></pre>
-              </div>
-            </div>
-            <div class="split-right">
-              <div v-if="currentScene.image" class="image-container">
-                <img :src="currentScene.image" :alt="currentScene.imageAlt" class="split-image" />
-              </div>
-              <div v-else class="visual-demo">
-                <div v-for="i in 5" :key="i" class="demo-bar" :style="{
-                  height: `${20 + Math.random() * 60}%`,
-                  animationDelay: `${i * 0.1}s`
-                }"></div>
-              </div>
-            </div>
-
-            <!-- Navigation positioned absolutely at bottom -->
-            <div class="unified-navigation" style="position: absolute; bottom: 1rem; left: 1rem; right: 1rem;">
-              <div class="scene-navigation-bottom">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Split view scene (reversed layout) -->
-          <div v-else-if="currentScene.type === 'split-reverse'" class="unified-split-content">
-            <div class="split-left">
-              <div v-if="currentScene.image" class="image-container">
-                <img :src="currentScene.image" :alt="currentScene.imageAlt" class="split-image" />
-              </div>
-            </div>
-            <div class="split-right">
-              <h2 class="scene-title">{{ currentScene.title }}</h2>
-              <p class="scene-description">{{ currentScene.description }}</p>
-              <div v-if="currentScene.code" class="code-block">
-                <pre><code>{{ currentScene.code }}</code></pre>
-              </div>
-            </div>
-
-            <!-- Navigation positioned absolutely at bottom -->
-            <div class="unified-navigation" style="position: absolute; bottom: 1rem; left: 1rem; right: 1rem;">
-              <div class="scene-navigation-bottom">
-                <button @click="previousScene" :disabled="currentSceneIndex === 0" class="nav-button prev">
-                  ← Vorige
-                </button>
-                <button @click="nextScene" :disabled="currentSceneIndex === scenes.length - 1" class="nav-button next">
-                  Volgende →
-                </button>
-              </div>
-            </div>
-          </div>
-
+          <component
+            :is="currentSceneComponent"
+            v-bind="componentProps"
+          />
         </div>
       </div>
     </transition>
-
   </div>
 </template>
 
-<script>
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import ChatInterface from './ChatInterface.vue'
-import WhisperLiveInterface from './WhisperLiveInterface.vue'
-import ConversationInterface from './ConversationInterface.vue'
+<script setup>
+import { computed } from 'vue'
+import { useStoryScene } from '../composables/useStoryScene.js'
+import StoryProgress from './story/StoryProgress.vue'
+import HeroScene from './story/HeroScene.vue'
+import TextScene from './story/TextScene.vue'
+import StatsScene from './story/StatsScene.vue'
+import ImagesScene from './story/ImagesScene.vue'
+import UtpScene from './story/UtpScene.vue'
+import ChatScene from './story/ChatScene.vue'
+import WhisperScene from './story/WhisperScene.vue'
+import ConversationScene from './story/ConversationScene.vue'
+import SplitScene from './story/SplitScene.vue'
 
-export default {
-  name: 'StoryScene',
-  components: {
-    ChatInterface,
-    WhisperLiveInterface,
-    ConversationInterface
-  },
-  emits: ['scene-change', 'blob-state-change'],
-  setup(props, { emit }) {
-    const currentSceneIndex = ref(0)
+const emit = defineEmits(['scene-change', 'blob-state-change'])
 
-    // Typewriter effect state
-    const displayedText = ref('')
-    const showCursor = ref(true)
-    const typewriterTimeout = ref(null)
-    const fullText = "Een reis door lokale AI-verwerking"
-    const typingSpeed = 80 // milliseconds per character
-    const deletingSpeed = 50 // milliseconds per character
-    const pauseBetweenCycles = 2000 // pause before starting to delete
-    const pauseBeforeRetyping = 1000 // pause before starting to type again
+const {
+  scenes,
+  currentSceneIndex,
+  currentScene,
+  displayedText,
+  showCursor,
+  nextScene,
+  previousScene,
+  goToScene,
+  handleStreamingChange,
+  handleConversationStateChange
+} = useStoryScene(emit)
 
-    // Enhanced scenes with different types
-    const scenes = [
-      {
-        type: 'hero',
-        title: "AI op Legacy Hardware",
-        description: "Een reis door lokale AI-verwerking",
-        blobState: "normal",
-        ctaText: "Begin Experience"
-      },
-      {
-        type: 'text',
-        title: "Fat Clients van Team Geo",
-        description: "Van 2000 tot 2025 gebruikte Team Geo krachtige werkstations voor geografische berekeningen en analyses. Deze 'fat clients' zijn uitgerust met GPU's.",
-        blobState: "normal",
-        backgroundImage: "src/assets/kaart.png",
-        points: [
-          "Fat Clients verhuis naar de cloud",
-          "Oude machines afgeschreven",
-          "Geo Workloads zijn te vertalen naar AI workloads",
-        ]
-      },
-      {
-        type: 'split',
-        title: "Links: De LLM Machine",
-        description: "Deze PC host een Large Language Model dat tekst begrijpt en genereert door woorden om te zetten naar vectoren in een multidimensionale ruimte.",
-        blobState: "left",
-        code: `// Word naar vector transformatie
-const wordVector = embedding_layer(token);
-// [0.2, -0.8, 0.1, 0.9, ...]
-// Attention mechanism
-const attention = softmax(
-  query * key_transpose / sqrt(dim));
-`,
-        image: "src/assets/vectors.jpeg",
-        imageAlt: "LLM Word Vector Visualization"
-      },
-      {
-        type: 'split-reverse',
-        title: "Rechts: De Whisper Machine",
-        description: "Deze PC transcribeert spraak naar tekst met OpenAI's Whisper model. Audio wordt omgezet naar spectrogrammen en vervolgens gedecodeerd naar woorden.",
-        blobState: "right",
-        code: `// Audio preprocessing
-const spectrogram = melSpectrogram(audio);
-// 80 mel-frequency bins
-// Encoder-decoder architectuur
-const encoded = encoder(spectrogram);
-const tokens = decoder(encoded);`,
-        image: "src/assets/Spectrograms.jpg",
-        imageAlt: "Whisper Audio Processing Pipeline"
-      },
-      {
-        type: 'utp',
-        title: "Lokale AI Verwerking",
-        description: "De computers hebben geen internetverbinding en communiceren alleen via een UTP-kabel. Alle AI-verwerking gebeurt lokaal, zonder externe afhankelijkheden.",
-        blobState: "normal",
-        points: [
-          "Geen internetverbinding - volledig offline systeem",
-          "Directe communicatie via UTP ethernet kabel",
-          "Alle data blijft lokaal en privé"
-        ]
-      },
-      {
-        type: 'chat',
-        title: "Probeer het Zelf",
-        // description: "Ervaar de AI in actie. Stel elke vraag!",
-        blobState: "left"
-      },
-      {
-        type: 'whisper',
-        title: "Real-time Spraakherkenning",
-        // description: "Ervaar live spraak-naar-tekst transcriptie met OpenAI's Whisper model dat lokaal draait.",
-        blobState: "right"
-      },
-      {
-        type: 'conversation',
-        title: "Spraakconversatie met AI",
-        description: "Voer een natuurlijk gesprek met de AI via je stem. Spreek natuurlijk en de AI zal antwoorden.",
-        blobState: "normal"
-      },
-//       {
-//         type: 'split',
-//         title: "Onder de Motorkap",
-//         description: "De systeemarchitectuur die het mogelijk maakt",
-//         blobState: "right",
-//         code: `// Vereenvoudigde inference loop
-// async function verwerkVraag(input) {
-//   const tokens = tokenize(input);
-//   const embeddings = embed(tokens);
-//   const response = await model.generate(embeddings);
-//   return decode(response);
-// }`
-//       },
-      {
-        type: 'text',
-        title: "We bepalen zelf de koers",
-        description: "Deze demonstratie laat zien hoe we AI toegankelijk maken voor overheden, onafhankelijk van grote techbedrijven. Zo behouden we privacy, controle en bepalen we zélf de koers.",
-        blobState: "normal",
-        showCompass: true,
-        // points: [
-        //   "Democratiseren van AI-toegang",
-        //   "Behoud van privacy en controle",
-        // ]
-      }
-    ]
+const sceneComponentMap = {
+  hero: HeroScene,
+  text: TextScene,
+  stats: StatsScene,
+  images: ImagesScene,
+  utp: UtpScene,
+  chat: ChatScene,
+  whisper: WhisperScene,
+  conversation: ConversationScene,
+  split: SplitScene,
+  'split-reverse': SplitScene
+}
 
-    const currentScene = computed(() => scenes[currentSceneIndex.value])
-    const progressPercentage = computed(() =>
-      ((currentSceneIndex.value + 1) / scenes.length) * 100
-    )
+const currentSceneComponent = computed(() => {
+  const type = currentScene.value?.type || 'text'
+  return sceneComponentMap[type] || TextScene
+})
 
-    const nextScene = () => {
-      if (currentSceneIndex.value < scenes.length - 1) {
-        currentSceneIndex.value++
-      }
-    }
+const hasBackground = computed(() => Boolean(currentScene.value?.backgroundImage))
 
-    const previousScene = () => {
-      if (currentSceneIndex.value > 0) {
-        currentSceneIndex.value--
-      }
-    }
+const backgroundStyle = computed(() => {
+  if (!currentScene.value?.backgroundImage) return {}
+  return { '--bg-image': `url(${currentScene.value.backgroundImage})` }
+})
 
-    // Typewriter effect functions
-    const startTypewriter = () => {
-      stopTypewriter() // Clear any existing timeouts
+const isFirstScene = computed(() => currentSceneIndex.value === 0)
+const isLastScene = computed(() => currentSceneIndex.value === scenes.length - 1)
 
-      let currentIndex = 0
-      let isDeleting = false
+const componentProps = computed(() => {
+  const type = currentScene.value?.type || 'text'
 
-      const typeStep = () => {
-        if (!isDeleting) {
-          // Typing forward
-          displayedText.value = fullText.substring(0, currentIndex + 1)
-          currentIndex++
-
-          if (currentIndex > fullText.length) {
-            // Finished typing, wait then start deleting
-            typewriterTimeout.value = setTimeout(() => {
-              isDeleting = true
-              typeStep()
-            }, pauseBetweenCycles)
-            return
-          }
-        } else {
-          // Deleting backward
-          displayedText.value = fullText.substring(0, currentIndex - 1)
-          currentIndex--
-
-          if (currentIndex <= 0) {
-            // Finished deleting, wait then start typing again
-            typewriterTimeout.value = setTimeout(() => {
-              isDeleting = false
-              currentIndex = 0
-              typeStep()
-            }, pauseBeforeRetyping)
-            return
-          }
-        }
-
-        // Continue with next character
-        const delay = isDeleting ? deletingSpeed : typingSpeed
-        typewriterTimeout.value = setTimeout(typeStep, delay)
-      }
-
-      // Start the animation
-      typeStep()
-    }
-
-    const stopTypewriter = () => {
-      if (typewriterTimeout.value) {
-        clearTimeout(typewriterTimeout.value)
-        typewriterTimeout.value = null
-      }
-    }
-
-    // Cursor blinking effect
-    const startCursorBlink = () => {
-      setInterval(() => {
-        showCursor.value = !showCursor.value
-      }, 500)
-    }
-
-    const handleStreamingChange = (isStreaming) => {
-      // Update blob state based on streaming and scene type
-      if (currentScene.value.type === 'whisper') {
-        // Whisper scene: blobs go right when streaming
-        const targetState = isStreaming ? 'right' : 'normal'
-        emit('blob-state-change', targetState)
-      } else if (currentScene.value.type === 'conversation') {
-        // Conversation scene: different states for listening vs responding
-        // When streaming is true, we're either transcribing (right) or AI is responding (left)
-        // We need to check the conversation state to determine which
-        // For now, we'll use a pattern where transcribing goes right, AI response goes left
-        const targetState = isStreaming ? 'right' : 'normal'
-        emit('blob-state-change', targetState)
-      } else if (currentScene.value.type === 'chat') {
-        // Chat scene: blobs go left when AI is responding
-        const targetState = isStreaming ? 'left' : 'normal'
-        emit('blob-state-change', targetState)
-      }
-    }
-
-    // Keyboard navigation
-    const handleKeypress = (e) => {
-      // Disable keyboard nav during chat, whisper, and conversation scenes
-      if (currentScene.value.type === 'chat' ||
-          currentScene.value.type === 'whisper' ||
-          currentScene.value.type === 'conversation') return
-
-      if (e.key === 'ArrowRight') nextScene()
-      if (e.key === 'ArrowLeft') previousScene()
-    }
-
-    // Watch for scene changes
-    watch(currentSceneIndex, (newIndex) => {
-      const scene = scenes[newIndex]
-      emit('scene-change', scene)
-      emit('blob-state-change', scene.blobState)
-
-      // Start/stop typewriter effect for hero scene
-      if (scene.type === 'hero') {
-        startTypewriter()
-      } else {
-        stopTypewriter()
-      }
-    })
-
-    onMounted(() => {
-      window.addEventListener('keydown', handleKeypress)
-      emit('scene-change', currentScene.value)
-      emit('blob-state-change', currentScene.value.blobState)
-
-      // Start cursor blinking
-      startCursorBlink()
-
-      // Start typewriter if starting on hero scene
-      if (currentScene.value.type === 'hero') {
-        startTypewriter()
-      }
-    })
-
-    onUnmounted(() => {
-      window.removeEventListener('keydown', handleKeypress)
-      stopTypewriter()
-    })
-
-    const handleConversationStateChange = (state) => {
-      // Handle conversation-specific state changes
-      if (state === 'listening') {
-        // User is speaking - blobs go right
-        emit('blob-state-change', 'right')
-      } else if (state === 'responding') {
-        // AI is responding - blobs go left
-        emit('blob-state-change', 'left')
-      } else {
-        // Idle/paused - blobs return to normal
-        emit('blob-state-change', 'normal')
-      }
-    }
-
+  if (type === 'hero') {
     return {
-      scenes,
-      currentSceneIndex,
-      currentScene,
-      progressPercentage,
-      nextScene,
-      previousScene,
-      handleStreamingChange,
-      handleConversationStateChange,
-      displayedText,
-      showCursor
+      scene: currentScene.value,
+      onNext: nextScene,
+      displayedText: displayedText.value,
+      showCursor: showCursor.value
     }
   }
-}
+
+  const props = {
+    scene: currentScene.value,
+    onNext: nextScene,
+    onPrevious: previousScene,
+    isFirst: isFirstScene.value,
+    isLast: isLastScene.value
+  }
+
+  if (type === 'text') {
+    props.currentIndex = currentSceneIndex.value
+    props.totalScenes = scenes.length
+  }
+
+  if (type === 'chat' || type === 'whisper') {
+    props.onStreamingChange = handleStreamingChange
+  }
+
+  if (type === 'conversation') {
+    props.onStreamingChange = handleStreamingChange
+    props.onConversationStateChange = handleConversationStateChange
+  }
+
+  if (type === 'split' || type === 'split-reverse') {
+    props.reverse = type === 'split-reverse'
+  }
+
+  return props
+})
 </script>
 
 <style scoped>
@@ -689,66 +130,10 @@ const tokens = decoder(encoded);`,
   padding: 2rem;
 }
 
-/* Progress bar */
-.progress-bar {
-  position: relative;
-  height: 4px;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 2px;
-  margin-bottom: 3rem;
-  overflow: visible;
-}
-
-.progress-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #dd0000 0%, #ff6666 100%);
-  border-radius: 2px;
-  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.progress-dots {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  right: 0;
-  transform: translateY(-50%);
-  display: flex;
-  justify-content: space-between;
-  padding: 0 10px;
-}
-
-.progress-dot {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.3);
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.progress-dot:hover {
-  transform: scale(1.2);
-  background: rgba(255, 255, 255, 0.5);
-}
-
-.progress-dot.active {
-  background: #fff;
-  border-color: #fff;
-  transform: scale(1.3);
-}
-
-.progress-dot.visited {
-  background: rgba(255, 255, 255, 0.7);
-  border-color: rgba(255, 255, 255, 0.8);
-}
-
-/* Scene wrapper */
 .scene-wrapper {
   min-height: 500px;
 }
 
-/* UNIFIED CONTAINER - All scenes use this */
 .scene-content-unified {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
@@ -761,11 +146,6 @@ const tokens = decoder(encoded);`,
   flex-direction: column;
   justify-content: space-between;
   overflow-y: auto;
-  position: relative;
-}
-
-/* Background image variant */
-.scene-content-unified.has-background {
   position: relative;
 }
 
@@ -791,184 +171,7 @@ const tokens = decoder(encoded);`,
   z-index: 1;
 }
 
-/* Specific layouts within the unified container */
-.unified-hero-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  flex: 1;
-}
-
-.unified-text-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  flex: 1;
-}
-
-.unified-stats-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-.unified-images-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-.unified-utp-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  flex: 1;
-}
-
-.unified-split-content {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2rem;
-  flex: 1;
-  position: relative;
-}
-
-.unified-chat-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
-/* Compass styling */
-.compass-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 2rem 0;
-}
-
-.compass-svg {
-  width: 300px;
-  height: 300px;
-  filter: drop-shadow(0 0 10px rgba(255, 102, 102, 0.3));
-  transition: all 0.3s ease;
-}
-
-.compass-svg:hover {
-  transform: scale(1.05);
-  filter: drop-shadow(0 0 15px rgba(255, 102, 102, 0.5));
-}
-
-/* UTP Visualization */
-.utp-visualization {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin: 1rem 0;
-  flex: 1;
-  min-height: 200px;
-}
-
-.pc-box {
-  background: rgba(255, 255, 255, 0.1);
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-radius: 15px;
-  padding: 2rem;
-  text-align: center;
-  min-width: 150px;
-  transition: all 0.3s ease;
-}
-
-.pc-box:hover {
-  background: rgba(255, 255, 255, 0.15);
-  border-color: rgba(255, 255, 255, 0.5);
-  transform: translateY(-5px);
-}
-
-.left-pc {
-  border-color: rgba(255, 102, 102, 0.5);
-}
-
-.right-pc {
-  border-color: rgba(102, 255, 102, 0.5);
-}
-
-.pc-label {
-  color: white;
-  font-weight: 600;
-  margin-bottom: 1rem;
-  font-size: 1.1rem;
-}
-
-.pc-icon {
-  font-size: 3rem;
-  margin-bottom: 0.5rem;
-}
-
-.utp-cable {
-  position: relative;
-  flex: 1;
-  height: 60px;
-  margin: 0 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.cable-line {
-  width: 100%;
-  height: 8px;
-  background: linear-gradient(90deg, #ff6666 0%, #66ff66 100%);
-  border-radius: 4px;
-  position: relative;
-  overflow: hidden;
-}
-
-.data-flow {
-  position: absolute;
-  top: 0;
-  left: -20px;
-  width: 40px;
-  height: 100%;
-  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.8) 50%, transparent 100%);
-  animation: data-flow 2s ease-in-out infinite;
-}
-
-.cable-label {
-  position: absolute;
-  bottom: -30px;
-  left: 50%;
-  transform: translateX(-50%);
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-@keyframes data-flow {
-  0% { left: -20px; }
-  100% { left: 100%; }
-}
-
-/* Navigation positioning for unified container */
-.unified-navigation {
-  margin-top: auto;
-  padding-top: 2rem;
-  flex-shrink: 0;
-}
-
-.unified-navigation-minimal {
-  margin-top: auto;
-  padding-top: 1rem;
-  flex-shrink: 0;
-}
-
-/* Scene content styles */
-.scene-text {
-  flex: 1;
-}
-
-.scene-title {
+.story-container :deep(.scene-title) {
   font-size: 2.5rem;
   font-weight: 800;
   color: white;
@@ -976,287 +179,34 @@ const tokens = decoder(encoded);`,
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-.scene-description {
+.story-container :deep(.scene-description) {
   font-size: 1.25rem;
   line-height: 1.8;
   color: rgba(255, 255, 255, 0.9);
   margin-bottom: 2rem;
 }
 
-.scene-points {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.scene-points li {
-  position: relative;
-  padding-left: 2rem;
-  margin-bottom: 1rem;
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 1.1rem;
-}
-
-.scene-points-text li {
-  position: relative;
-  padding-left: 2rem;
-  margin-bottom: 1rem;
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 1.3rem;
-}
-
-.scene-points-text li::before {
-  content: "→";
-  position: absolute;
-  left: 0;
-  color: #ff6666;
-  font-weight: bold;
-}
-
-.scene-points li::before {
-  content: "→";
-  position: absolute;
-  left: 0;
-  color: #ff6666;
-  font-weight: bold;
-}
-
-/* Hero scene styles */
-.hero-content {
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-.hero-title {
-  font-size: 4rem;
-  font-weight: 900;
-  color: white;
-  margin-bottom: 2rem;
-  text-shadow: 3px 3px 6px rgba(0, 0, 0, 0.4);
-  line-height: 1.1;
-}
-
-.hero-description {
-  font-size: 1.5rem;
-  color: rgba(255, 255, 255, 0.9);
-  margin-bottom: 3rem;
-  line-height: 1.6;
-  min-height: 2em;
+.story-container :deep(.scene-navigation),
+.story-container :deep(.scene-navigation-minimal),
+.story-container :deep(.scene-navigation-bottom) {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
 }
 
-.typewriter-text {
-  display: inline;
-}
-
-.cursor {
-  display: inline-block;
-  color: #ff6666;
-  font-weight: bold;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-}
-
-.cursor.visible {
-  opacity: 1;
-}
-
-.hero-cta {
-  background: linear-gradient(135deg, #dd0000 0%, #ff6666 100%);
-  color: white;
-  border: none;
-  padding: 1rem 3rem;
-  font-size: 1.25rem;
-  font-weight: 700;
-  border-radius: 50px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 20px rgba(221, 0, 0, 0.3);
-}
-
-.hero-cta:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 30px rgba(221, 0, 0, 0.4);
-}
-
-/* Scene header for chat interfaces */
-.scene-header {
-  text-align: center;
-  margin-bottom: 1.5rem;
+.story-container :deep(.unified-navigation) {
+  margin-top: auto;
+  padding-top: 2rem;
   flex-shrink: 0;
 }
 
-.scene-subtitle {
-  font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.7);
-  margin-top: 0.5rem;
+.story-container :deep(.unified-navigation-minimal) {
+  margin-top: auto;
+  padding-top: 1rem;
+  flex-shrink: 0;
 }
 
-/* Images scene */
-.images-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-  margin: 2rem 0;
-  flex: 1;
-}
-
-.image-card {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 15px;
-  padding: 1.5rem;
-  text-align: center;
-  transition: all 0.3s ease;
-  overflow: hidden;
-}
-
-.image-card:hover {
-  transform: translateY(-5px);
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.performance-image {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
-  border-radius: 10px;
-  margin-bottom: 1rem;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.image-caption {
-  font-size: 1rem;
-  color: white;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-/* Split scene image container */
-.image-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  padding: 1rem;
-}
-
-.split-image {
-  width: 100%;
-  max-height: 300px;
-  object-fit: contain;
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 2rem;
-  margin: 2rem 0;
-  flex: 1;
-}
-
-.stat-card {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 15px;
-  padding: 2rem;
-  text-align: center;
-  transition: all 0.3s ease;
-}
-
-.stat-card:hover {
-  transform: translateY(-5px);
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.stat-value {
-  font-size: 3rem;
-  font-weight: 800;
-  color: #ff6666;
-  margin-bottom: 0.5rem;
-}
-
-.stat-label {
-  font-size: 1.1rem;
-  color: white;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-}
-
-.stat-detail {
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-/* Split scene adjustments */
-.split-left, .split-right {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 15px;
-  padding: 1.5rem;
-}
-
-.code-block {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 10px;
-  padding: 1.5rem;
-  margin-top: 2rem;
-  font-family: 'Monaco', 'Consolas', monospace;
-}
-
-.code-block pre {
-  margin: 0;
-  color: #fff;
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.visual-demo {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-around;
-  height: 300px;
-  padding: 2rem;
-}
-
-.demo-bar {
-  width: 40px;
-  background: linear-gradient(to top, #ff6666, #dd0000);
-  border-radius: 5px 5px 0 0;
-  animation: pulse-height 2s ease-in-out infinite;
-}
-
-@keyframes pulse-height {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 1; }
-}
-
-/* Navigation variants */
-.scene-navigation {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.scene-navigation-minimal {
-  display: flex;
-  justify-content: space-between;
-}
-
-.scene-navigation-bottom {
-  display: flex;
-  justify-content: space-between;
-}
-
-.nav-button {
+.story-container :deep(.nav-button) {
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.3);
   color: white;
@@ -1268,31 +218,31 @@ const tokens = decoder(encoded);`,
   transition: all 0.3s ease;
 }
 
-.nav-button:hover:not(:disabled) {
+.story-container :deep(.nav-button:hover:not(:disabled)) {
   background: rgba(255, 255, 255, 0.2);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-.nav-button:disabled {
+.story-container :deep(.nav-button:disabled) {
   opacity: 0.3;
   cursor: not-allowed;
 }
 
-.scene-counter {
+.story-container :deep(.scene-counter) {
   color: rgba(255, 255, 255, 0.7);
   font-size: 0.9rem;
 }
 
-/* Keyboard hint */
-.keyboard-hint {
-  text-align: center;
-  margin-top: 2rem;
-  color: rgba(255, 255, 255, 0.5);
-  font-size: 0.9rem;
+.story-container :deep(.scene-header) {
+  margin-bottom: 1.5rem;
 }
 
-/* Transitions */
+.story-container :deep(.scene-subtitle) {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.5s ease, transform 0.5s ease;
@@ -1308,7 +258,6 @@ const tokens = decoder(encoded);`,
   transform: translateX(-30px);
 }
 
-/* Responsive */
 @media (max-width: 768px) {
   .story-container {
     padding: 1rem;
@@ -1321,38 +270,6 @@ const tokens = decoder(encoded);`,
 
   .scene-title {
     font-size: 2rem;
-  }
-
-  .hero-title {
-    font-size: 2.5rem;
-  }
-
-  .unified-split-content {
-    grid-template-columns: 1fr;
-  }
-
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .utp-visualization {
-    flex-direction: column;
-    gap: 2rem;
-  }
-
-  .utp-cable {
-    transform: rotate(90deg);
-    width: 60px;
-    margin: 1rem 0;
-  }
-
-  .cable-label {
-    transform: translateX(-50%) rotate(-90deg);
-  }
-
-  .compass-svg {
-    width: 120px;
-    height: 120px;
   }
 }
 </style>

--- a/src/components/story/ChatScene.vue
+++ b/src/components/story/ChatScene.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="chat-scene">
+    <div class="scene-header">
+      <h2 class="scene-title">{{ scene.title }}</h2>
+      <p v-if="scene.description" class="scene-subtitle">{{ scene.description }}</p>
+    </div>
+
+    <ChatInterface @streaming-change="onStreamingChange" />
+
+    <div class="unified-navigation-minimal">
+      <div class="scene-navigation-minimal">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Terug
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Doorgaan →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ChatInterface from '../ChatInterface.vue'
+
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  },
+  onStreamingChange: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious, onStreamingChange } = props
+</script>
+
+<style scoped>
+.chat-scene {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+</style>

--- a/src/components/story/ConversationScene.vue
+++ b/src/components/story/ConversationScene.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="chat-scene">
+    <div class="scene-header">
+      <h2 class="scene-title">{{ scene.title }}</h2>
+      <p v-if="scene.description" class="scene-subtitle">{{ scene.description }}</p>
+    </div>
+
+    <ConversationInterface
+      @streaming-change="onStreamingChange"
+      @conversation-state-change="onConversationStateChange"
+    />
+
+    <div class="unified-navigation-minimal">
+      <div class="scene-navigation-minimal">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Terug
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Doorgaan →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ConversationInterface from '../ConversationInterface.vue'
+
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  },
+  onStreamingChange: {
+    type: Function,
+    required: true
+  },
+  onConversationStateChange: {
+    type: Function,
+    required: true
+  }
+})
+
+const {
+  scene,
+  isFirst,
+  isLast,
+  onNext,
+  onPrevious,
+  onStreamingChange,
+  onConversationStateChange
+} = props
+</script>
+
+<style scoped>
+.chat-scene {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+</style>

--- a/src/components/story/HeroScene.vue
+++ b/src/components/story/HeroScene.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="unified-hero-content">
+    <div class="hero-content">
+      <h1 class="hero-title">{{ scene.title }}</h1>
+      <p class="hero-description">
+        <span class="typewriter-text">{{ displayedText }}</span>
+        <span class="cursor" :class="{ visible: showCursor }">|</span>
+      </p>
+      <button class="hero-cta" @click="onNext">
+        {{ scene.ctaText || 'Start Journey' }} →
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { toRefs } from 'vue'
+
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  displayedText: {
+    type: String,
+    default: ''
+  },
+  showCursor: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const { scene, onNext, displayedText, showCursor } = toRefs(props)
+</script>
+
+<style scoped>
+.unified-hero-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  flex: 1;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-title {
+  font-size: 4rem;
+  font-weight: 900;
+  color: white;
+  margin-bottom: 2rem;
+  text-shadow: 3px 3px 6px rgba(0, 0, 0, 0.4);
+  line-height: 1.1;
+}
+
+.hero-description {
+  font-size: 1.5rem;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 3rem;
+  min-height: 2em;
+  line-height: 1.6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.typewriter-text {
+  display: inline;
+}
+
+.cursor {
+  display: inline-block;
+  color: #ff6666;
+  font-weight: bold;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.cursor.visible {
+  opacity: 1;
+}
+
+.hero-cta {
+  background: linear-gradient(135deg, #dd0000 0%, #ff6666 100%);
+  color: white;
+  border: none;
+  padding: 1rem 3rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-radius: 50px;
+  box-shadow: 0 4px 20px rgba(221, 0, 0, 0.3);
+}
+
+.hero-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(221, 0, 0, 0.4);
+}
+</style>

--- a/src/components/story/ImagesScene.vue
+++ b/src/components/story/ImagesScene.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="images-scene">
+    <h2 class="scene-title">{{ scene.title }}</h2>
+    <div class="images-grid">
+      <div v-for="image in scene.images" :key="image.alt" class="image-card">
+        <img :src="image.src" :alt="image.alt" class="performance-image" />
+        <div class="image-caption">{{ image.caption }}</div>
+      </div>
+    </div>
+
+    <div class="unified-navigation">
+      <div class="scene-navigation">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Vorige
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Volgende →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious } = props
+</script>
+
+<style scoped>
+.images-scene {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.images-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+  flex: 1;
+}
+
+.image-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 15px;
+  padding: 1.5rem;
+  text-align: center;
+  transition: all 0.3s ease;
+  overflow: hidden;
+}
+
+.image-card:hover {
+  transform: translateY(-5px);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.performance-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 10px;
+  margin-bottom: 1rem;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.image-caption {
+  font-size: 1rem;
+  color: white;
+  font-weight: 600;
+  line-height: 1.4;
+}
+</style>

--- a/src/components/story/SplitScene.vue
+++ b/src/components/story/SplitScene.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="split-scene">
+    <div class="split-left">
+      <template v-if="!reverse">
+        <h2 class="scene-title">{{ scene.title }}</h2>
+        <p class="scene-description">{{ scene.description }}</p>
+        <div v-if="scene.code" class="code-block">
+          <pre><code>{{ scene.code }}</code></pre>
+        </div>
+      </template>
+      <template v-else>
+        <div v-if="scene.image" class="image-container">
+          <img :src="scene.image" :alt="scene.imageAlt" class="split-image" />
+        </div>
+      </template>
+    </div>
+
+    <div class="split-right">
+      <template v-if="reverse">
+        <h2 class="scene-title">{{ scene.title }}</h2>
+        <p class="scene-description">{{ scene.description }}</p>
+        <div v-if="scene.code" class="code-block">
+          <pre><code>{{ scene.code }}</code></pre>
+        </div>
+      </template>
+      <template v-else>
+        <div v-if="scene.image" class="image-container">
+          <img :src="scene.image" :alt="scene.imageAlt" class="split-image" />
+        </div>
+        <div v-else class="visual-demo">
+          <div
+            v-for="(height, index) in demoBars"
+            :key="index"
+            class="demo-bar"
+            :style="{ height: `${height}%`, animationDelay: `${index * 0.1}s` }"
+          ></div>
+        </div>
+      </template>
+    </div>
+
+    <div class="unified-navigation navigation-bottom">
+      <div class="scene-navigation-bottom">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Vorige
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Volgende →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  },
+  reverse: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious, reverse } = props
+
+const demoBars = ref(Array.from({ length: 5 }, () => 20 + Math.random() * 60))
+</script>
+
+<style scoped>
+.split-scene {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  flex: 1;
+  position: relative;
+}
+
+.split-left,
+.split-right {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 15px;
+  padding: 1.5rem;
+}
+
+.image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1rem;
+}
+
+.split-image {
+  width: 100%;
+  max-height: 300px;
+  object-fit: contain;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.visual-demo {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+  height: 300px;
+  padding: 2rem;
+}
+
+.demo-bar {
+  width: 40px;
+  background: linear-gradient(to top, #ff6666, #dd0000);
+  border-radius: 5px 5px 0 0;
+  animation: pulse-height 2s ease-in-out infinite;
+}
+
+.navigation-bottom {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  right: 1rem;
+}
+
+.code-block {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-top: 2rem;
+  font-family: 'Monaco', 'Consolas', monospace;
+}
+
+.code-block pre {
+  margin: 0;
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+@keyframes pulse-height {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/story/StatsScene.vue
+++ b/src/components/story/StatsScene.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="stats-scene">
+    <h2 class="scene-title">{{ scene.title }}</h2>
+    <div class="stats-grid">
+      <div v-for="stat in scene.stats" :key="stat.label" class="stat-card">
+        <div class="stat-value">{{ stat.value }}</div>
+        <div class="stat-label">{{ stat.label }}</div>
+        <div v-if="stat.detail" class="stat-detail">{{ stat.detail }}</div>
+      </div>
+    </div>
+
+    <div class="unified-navigation">
+      <div class="scene-navigation">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Vorige
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Volgende →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious } = props
+</script>
+
+<style scoped>
+.stats-scene {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+  flex: 1;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 15px;
+  padding: 2rem;
+  text-align: center;
+  transition: all 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-5px);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.stat-value {
+  font-size: 3rem;
+  font-weight: 800;
+  color: #ff6666;
+  margin-bottom: 0.5rem;
+}
+
+.stat-label {
+  font-size: 1.1rem;
+  color: white;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.stat-detail {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+</style>

--- a/src/components/story/StoryProgress.vue
+++ b/src/components/story/StoryProgress.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="progress-bar">
+    <div class="progress-fill" :style="{ width: `${progressPercentage}%` }"></div>
+    <div class="progress-dots">
+      <button
+        v-for="(scene, index) in scenes"
+        :key="index"
+        class="progress-dot"
+        :class="{
+          active: index === currentSceneIndex,
+          visited: index < currentSceneIndex
+        }"
+        :title="scene.title"
+        @click="handleSelect(index)"
+      ></button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  scenes: {
+    type: Array,
+    required: true
+  },
+  currentSceneIndex: {
+    type: Number,
+    required: true
+  }
+})
+
+const emit = defineEmits(['change'])
+
+const progressPercentage = computed(() => {
+  if (!props.scenes.length) return 0
+  return ((props.currentSceneIndex + 1) / props.scenes.length) * 100
+})
+
+const handleSelect = (index) => {
+  emit('change', index)
+}
+</script>
+
+<style scoped>
+.progress-bar {
+  position: relative;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  margin-bottom: 3rem;
+  overflow: visible;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #dd0000 0%, #ff6666 100%);
+  border-radius: 2px;
+  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.progress-dots {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: space-between;
+  padding: 0 10px;
+}
+
+.progress-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.progress-dot:hover {
+  transform: scale(1.2);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.progress-dot.active {
+  background: #fff;
+  border-color: #fff;
+  transform: scale(1.3);
+}
+
+.progress-dot.visited {
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(255, 255, 255, 0.8);
+}
+</style>

--- a/src/components/story/TextScene.vue
+++ b/src/components/story/TextScene.vue
@@ -1,0 +1,195 @@
+<template>
+  <div class="text-scene">
+    <div class="scene-text">
+      <h2 class="scene-title">{{ scene.title }}</h2>
+      <p class="scene-description">{{ scene.description }}</p>
+
+      <div v-if="scene.showCompass" class="compass-container">
+        <svg viewBox="0 0 200 200" class="compass-svg">
+          <defs>
+            <radialGradient id="outerRing" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.2" />
+              <stop offset="70%" style="stop-color:#ffffff;stop-opacity:0.1" />
+              <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0.3" />
+            </radialGradient>
+
+            <radialGradient id="innerRing" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.3" />
+              <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0.1" />
+            </radialGradient>
+
+            <linearGradient id="needleNorth" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" style="stop-color:#ff6666" />
+              <stop offset="100%" style="stop-color:#dd0000" />
+            </linearGradient>
+
+            <linearGradient id="needleSouth" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" style="stop-color:#666666" />
+              <stop offset="100%" style="stop-color:#333333" />
+            </linearGradient>
+
+            <filter id="glow">
+              <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+              <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+
+          <circle cx="100" cy="100" r="90" fill="none" stroke="url(#outerRing)" stroke-width="3" opacity="0.8" />
+          <circle cx="100" cy="100" r="70" fill="none" stroke="url(#innerRing)" stroke-width="2" opacity="0.6" />
+
+          <g stroke="rgba(255,255,255,0.7)" stroke-width="2" fill="none">
+            <line x1="100" y1="20" x2="100" y2="35" />
+            <line x1="180" y1="100" x2="165" y2="100" />
+            <line x1="100" y1="180" x2="100" y2="165" />
+            <line x1="20" y1="100" x2="35" y2="100" />
+          </g>
+
+          <g stroke="rgba(255,255,255,0.5)" stroke-width="1" fill="none">
+            <line x1="163.6" y1="36.4" x2="156.4" y2="43.6" />
+            <line x1="163.6" y1="163.6" x2="156.4" y2="156.4" />
+            <line x1="36.4" y1="163.6" x2="43.6" y2="156.4" />
+            <line x1="36.4" y1="36.4" x2="43.6" y2="43.6" />
+          </g>
+
+          <g fill="rgba(255,255,255,0.9)" font-family="Arial, sans-serif" font-size="16" font-weight="bold" text-anchor="middle">
+            <text x="100" y="15" dominant-baseline="middle">N</text>
+            <text x="190" y="105" dominant-baseline="middle">O</text>
+            <text x="100" y="195" dominant-baseline="middle">Z</text>
+            <text x="10" y="105" dominant-baseline="middle">W</text>
+          </g>
+
+          <g filter="url(#glow)">
+            <polygon points="100,100 95,45 100,35 105,45" fill="url(#needleNorth)" stroke="rgba(255,255,255,0.3)" stroke-width="1">
+              <animateTransform attributeName="transform" attributeType="XML" type="rotate" values="0 100 100;5 100 100;-5 100 100;0 100 100" dur="4s" repeatCount="indefinite" />
+            </polygon>
+
+            <polygon points="100,100 105,155 100,165 95,155" fill="url(#needleSouth)" stroke="rgba(255,255,255,0.2)" stroke-width="1">
+              <animateTransform attributeName="transform" attributeType="XML" type="rotate" values="0 100 100;5 100 100;-5 100 100;0 100 100" dur="4s" repeatCount="indefinite" />
+            </polygon>
+          </g>
+
+          <circle cx="100" cy="100" r="6" fill="rgba(255,255,255,0.9)" stroke="rgba(255,102,102,0.8)" stroke-width="2">
+            <animate attributeName="r" values="6;8;6" dur="2s" repeatCount="indefinite" />
+          </circle>
+
+          <g stroke="rgba(255,255,255,0.3)" stroke-width="1" fill="none">
+            <path d="M 30 30 L 40 30 M 30 30 L 30 40" />
+            <path d="M 170 30 L 160 30 M 170 30 L 170 40" />
+            <path d="M 170 170 L 160 170 M 170 170 L 170 160" />
+            <path d="M 30 170 L 40 170 M 30 170 L 30 160" />
+          </g>
+        </svg>
+      </div>
+
+      <ul v-if="scene.points" class="scene-points-text">
+        <li v-for="(point, idx) in scene.points" :key="idx">
+          {{ point }}
+        </li>
+      </ul>
+    </div>
+
+    <div class="unified-navigation">
+      <div class="scene-navigation">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Vorige
+        </button>
+        <span class="scene-counter">{{ currentIndex + 1 }} / {{ totalScenes }}</span>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Volgende →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  currentIndex: {
+    type: Number,
+    required: true
+  },
+  totalScenes: {
+    type: Number,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, currentIndex, totalScenes, isFirst, isLast, onNext, onPrevious } = props
+</script>
+
+<style scoped>
+.text-scene {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
+}
+
+.scene-text {
+  flex: 1;
+}
+
+.compass-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 2rem 0;
+}
+
+.compass-svg {
+  width: 300px;
+  height: 300px;
+  filter: drop-shadow(0 0 10px rgba(255, 102, 102, 0.3));
+  transition: all 0.3s ease;
+}
+
+.compass-svg:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(0 0 15px rgba(255, 102, 102, 0.5));
+}
+
+.scene-points-text {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.scene-points-text li {
+  position: relative;
+  padding-left: 2rem;
+  margin-bottom: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.3rem;
+}
+
+.scene-points-text li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: #ff6666;
+  font-weight: bold;
+}
+</style>

--- a/src/components/story/UtpScene.vue
+++ b/src/components/story/UtpScene.vue
@@ -1,0 +1,192 @@
+<template>
+  <div class="utp-scene">
+    <h2 class="scene-title">{{ scene.title }}</h2>
+    <p class="scene-description">{{ scene.description }}</p>
+
+    <div class="utp-visualization">
+      <div class="pc-box left-pc">
+        <div class="pc-label">LLM Machine</div>
+        <div class="pc-icon">💻</div>
+      </div>
+
+      <div class="utp-cable">
+        <div class="cable-line"></div>
+        <div class="data-flow"></div>
+        <div class="cable-label">UTP ethernet Kabel</div>
+      </div>
+
+      <div class="pc-box right-pc">
+        <div class="pc-label">Whisper Machine</div>
+        <div class="pc-icon">💻</div>
+      </div>
+    </div>
+
+    <ul v-if="scene.points" class="scene-points">
+      <li v-for="(point, idx) in scene.points" :key="idx">
+        {{ point }}
+      </li>
+    </ul>
+
+    <div class="unified-navigation">
+      <div class="scene-navigation">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Vorige
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Volgende →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious } = props
+</script>
+
+<style scoped>
+.utp-scene {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
+}
+
+.utp-visualization {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 1rem 0;
+  flex: 1;
+  min-height: 200px;
+}
+
+.pc-box {
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 15px;
+  padding: 2rem;
+  text-align: center;
+  min-width: 150px;
+  transition: all 0.3s ease;
+}
+
+.pc-box:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.5);
+  transform: translateY(-5px);
+}
+
+.left-pc {
+  border-color: rgba(255, 102, 102, 0.5);
+}
+
+.right-pc {
+  border-color: rgba(102, 255, 102, 0.5);
+}
+
+.pc-label {
+  color: white;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.pc-icon {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+.utp-cable {
+  position: relative;
+  flex: 1;
+  height: 60px;
+  margin: 0 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cable-line {
+  width: 100%;
+  height: 8px;
+  background: linear-gradient(90deg, #ff6666 0%, #66ff66 100%);
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+
+.data-flow {
+  position: absolute;
+  top: 0;
+  left: -20px;
+  width: 40px;
+  height: 100%;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.8) 50%, transparent 100%);
+  animation: data-flow 2s ease-in-out infinite;
+}
+
+.cable-label {
+  position: absolute;
+  bottom: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+@keyframes data-flow {
+  0% {
+    left: -20px;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+.scene-points {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.scene-points li {
+  position: relative;
+  padding-left: 2rem;
+  margin-bottom: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.1rem;
+}
+
+.scene-points li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: #ff6666;
+  font-weight: bold;
+}
+</style>

--- a/src/components/story/WhisperScene.vue
+++ b/src/components/story/WhisperScene.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="chat-scene">
+    <div class="scene-header">
+      <h2 class="scene-title">{{ scene.title }}</h2>
+      <p v-if="scene.description" class="scene-subtitle">{{ scene.description }}</p>
+    </div>
+
+    <WhisperLiveInterface @streaming-change="onStreamingChange" />
+
+    <div class="unified-navigation-minimal">
+      <div class="scene-navigation-minimal">
+        <button class="nav-button prev" :disabled="isFirst" @click="onPrevious">
+          ← Terug
+        </button>
+        <button class="nav-button next" :disabled="isLast" @click="onNext">
+          Doorgaan →
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import WhisperLiveInterface from '../WhisperLiveInterface.vue'
+
+const props = defineProps({
+  scene: {
+    type: Object,
+    required: true
+  },
+  isFirst: {
+    type: Boolean,
+    required: true
+  },
+  isLast: {
+    type: Boolean,
+    required: true
+  },
+  onNext: {
+    type: Function,
+    required: true
+  },
+  onPrevious: {
+    type: Function,
+    required: true
+  },
+  onStreamingChange: {
+    type: Function,
+    required: true
+  }
+})
+
+const { scene, isFirst, isLast, onNext, onPrevious, onStreamingChange } = props
+</script>
+
+<style scoped>
+.chat-scene {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+</style>

--- a/src/composables/useStoryScene.js
+++ b/src/composables/useStoryScene.js
@@ -1,0 +1,185 @@
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { storyScenes } from '../data/storyScenes.js'
+
+const fullText = 'Een reis door lokale AI-verwerking'
+const typingSpeed = 80
+const deletingSpeed = 50
+const pauseBetweenCycles = 2000
+const pauseBeforeRetyping = 1000
+
+export const useStoryScene = (emit) => {
+  const scenes = storyScenes
+  const currentSceneIndex = ref(0)
+  const displayedText = ref('')
+  const showCursor = ref(true)
+  const typewriterTimeout = ref(null)
+  const cursorInterval = ref(null)
+
+  const currentScene = computed(() => scenes[currentSceneIndex.value])
+
+  const progressPercentage = computed(() => {
+    if (!scenes.length) return 0
+    return ((currentSceneIndex.value + 1) / scenes.length) * 100
+  })
+
+  const nextScene = () => {
+    if (currentSceneIndex.value < scenes.length - 1) {
+      currentSceneIndex.value += 1
+    }
+  }
+
+  const previousScene = () => {
+    if (currentSceneIndex.value > 0) {
+      currentSceneIndex.value -= 1
+    }
+  }
+
+  const goToScene = (index) => {
+    if (index >= 0 && index < scenes.length) {
+      currentSceneIndex.value = index
+    }
+  }
+
+  const stopTypewriter = () => {
+    if (typewriterTimeout.value) {
+      clearTimeout(typewriterTimeout.value)
+      typewriterTimeout.value = null
+    }
+  }
+
+  const startTypewriter = () => {
+    stopTypewriter()
+
+    let currentIndex = 0
+    let isDeleting = false
+
+    const typeStep = () => {
+      if (!isDeleting) {
+        displayedText.value = fullText.substring(0, currentIndex + 1)
+        currentIndex += 1
+
+        if (currentIndex > fullText.length) {
+          typewriterTimeout.value = setTimeout(() => {
+            isDeleting = true
+            typeStep()
+          }, pauseBetweenCycles)
+          return
+        }
+      } else {
+        displayedText.value = fullText.substring(0, currentIndex - 1)
+        currentIndex -= 1
+
+        if (currentIndex <= 0) {
+          typewriterTimeout.value = setTimeout(() => {
+            isDeleting = false
+            currentIndex = 0
+            typeStep()
+          }, pauseBeforeRetyping)
+          return
+        }
+      }
+
+      const delay = isDeleting ? deletingSpeed : typingSpeed
+      typewriterTimeout.value = setTimeout(typeStep, delay)
+    }
+
+    typeStep()
+  }
+
+  const startCursorBlink = () => {
+    if (cursorInterval.value) return
+
+    cursorInterval.value = setInterval(() => {
+      showCursor.value = !showCursor.value
+    }, 500)
+  }
+
+  const stopCursorBlink = () => {
+    if (cursorInterval.value) {
+      clearInterval(cursorInterval.value)
+      cursorInterval.value = null
+      showCursor.value = true
+    }
+  }
+
+  const handleStreamingChange = (isStreaming) => {
+    const type = currentScene.value?.type
+
+    if (type === 'whisper') {
+      emit('blob-state-change', isStreaming ? 'right' : 'normal')
+    } else if (type === 'conversation') {
+      emit('blob-state-change', isStreaming ? 'right' : 'normal')
+    } else if (type === 'chat') {
+      emit('blob-state-change', isStreaming ? 'left' : 'normal')
+    }
+  }
+
+  const handleConversationStateChange = (state) => {
+    if (state === 'listening') {
+      emit('blob-state-change', 'right')
+    } else if (state === 'responding') {
+      emit('blob-state-change', 'left')
+    } else {
+      emit('blob-state-change', 'normal')
+    }
+  }
+
+  const handleKeypress = (event) => {
+    const disabledTypes = ['chat', 'whisper', 'conversation']
+    if (disabledTypes.includes(currentScene.value?.type)) return
+
+    if (event.key === 'ArrowRight') {
+      nextScene()
+    }
+
+    if (event.key === 'ArrowLeft') {
+      previousScene()
+    }
+  }
+
+  watch(currentSceneIndex, (newIndex) => {
+    const scene = scenes[newIndex]
+    emit('scene-change', scene)
+    emit('blob-state-change', scene.blobState)
+
+    if (scene.type === 'hero') {
+      startTypewriter()
+    } else {
+      stopTypewriter()
+      displayedText.value = ''
+    }
+  })
+
+  onMounted(() => {
+    window.addEventListener('keydown', handleKeypress)
+    const initialScene = currentScene.value
+    emit('scene-change', initialScene)
+    emit('blob-state-change', initialScene.blobState)
+
+    startCursorBlink()
+
+    if (initialScene.type === 'hero') {
+      startTypewriter()
+    }
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('keydown', handleKeypress)
+    stopTypewriter()
+    stopCursorBlink()
+  })
+
+  return {
+    scenes,
+    currentSceneIndex,
+    currentScene,
+    progressPercentage,
+    displayedText,
+    showCursor,
+    nextScene,
+    previousScene,
+    goToScene,
+    handleStreamingChange,
+    handleConversationStateChange
+  }
+}

--- a/src/data/storyScenes.js
+++ b/src/data/storyScenes.js
@@ -1,0 +1,89 @@
+export const storyScenes = [
+  {
+    type: 'hero',
+    title: 'AI op Legacy Hardware',
+    description: 'Een reis door lokale AI-verwerking',
+    blobState: 'normal',
+    ctaText: 'Begin Experience'
+  },
+  {
+    type: 'text',
+    title: 'Fat Clients van Team Geo',
+    description:
+      "Van 2000 tot 2025 gebruikte Team Geo krachtige werkstations voor geografische berekeningen en analyses. Deze 'fat clients' zijn uitgerust met GPU's.",
+    blobState: 'normal',
+    backgroundImage: 'src/assets/kaart.png',
+    points: [
+      'Fat Clients verhuis naar de cloud',
+      'Oude machines afgeschreven',
+      'Geo Workloads zijn te vertalen naar AI workloads'
+    ]
+  },
+  {
+    type: 'split',
+    title: 'Links: De LLM Machine',
+    description:
+      'Deze PC host een Large Language Model dat tekst begrijpt en genereert door woorden om te zetten naar vectoren in een multidimensionale ruimte.',
+    blobState: 'left',
+    code: `// Word naar vector transformatie
+const wordVector = embedding_layer(token);
+// [0.2, -0.8, 0.1, 0.9, ...]
+// Attention mechanism
+const attention = softmax(
+  query * key_transpose / sqrt(dim));`,
+    image: 'src/assets/vectors.jpeg',
+    imageAlt: 'LLM Word Vector Visualization'
+  },
+  {
+    type: 'split-reverse',
+    title: 'Rechts: De Whisper Machine',
+    description:
+      "Deze PC transcribeert spraak naar tekst met OpenAI's Whisper model. Audio wordt omgezet naar spectrogrammen en vervolgens gedecodeerd naar woorden.",
+    blobState: 'right',
+    code: `// Audio preprocessing
+const spectrogram = melSpectrogram(audio);
+// 80 mel-frequency bins
+// Encoder-decoder architectuur
+const encoded = encoder(spectrogram);
+const tokens = decoder(encoded);`,
+    image: 'src/assets/Spectrograms.jpg',
+    imageAlt: 'Whisper Audio Processing Pipeline'
+  },
+  {
+    type: 'utp',
+    title: 'Lokale AI Verwerking',
+    description:
+      'De computers hebben geen internetverbinding en communiceren alleen via een UTP-kabel. Alle AI-verwerking gebeurt lokaal, zonder externe afhankelijkheden.',
+    blobState: 'normal',
+    points: [
+      'Geen internetverbinding - volledig offline systeem',
+      'Directe communicatie via UTP ethernet kabel',
+      'Alle data blijft lokaal en privé'
+    ]
+  },
+  {
+    type: 'chat',
+    title: 'Probeer het Zelf',
+    blobState: 'left'
+  },
+  {
+    type: 'whisper',
+    title: 'Real-time Spraakherkenning',
+    blobState: 'right'
+  },
+  {
+    type: 'conversation',
+    title: 'Spraakconversatie met AI',
+    description:
+      'Voer een natuurlijk gesprek met de AI via je stem. Spreek natuurlijk en de AI zal antwoorden.',
+    blobState: 'normal'
+  },
+  {
+    type: 'text',
+    title: 'We bepalen zelf de koers',
+    description:
+      'Deze demonstratie laat zien hoe we AI toegankelijk maken voor overheden, onafhankelijk van grote techbedrijven. Zo behouden we privacy, controle en bepalen we zélf de koers.',
+    blobState: 'normal',
+    showCompass: true
+  }
+]


### PR DESCRIPTION
## Summary
- extract each scene branch into dedicated components and add a reusable StoryProgress indicator
- move story data into src/data/storyScenes.js and encapsulate navigation, typewriter, and blob logic in a useStoryScene composable
- refactor StoryScene.vue into an orchestrator that renders scene components dynamically and keeps shared styling centralized
- ensure shared story styles apply within child components and restore the hero scene typewriter animation
- realign the hero, stats, images, and split scene components with the original gradients, typography, and button layout so the UI matches the pre-refactor design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab5a262c4832fb3641dc4702da033